### PR TITLE
AE-1625 Take front page ET count from statistics

### DIFF
--- a/src/api/energiatodistus-api.js
+++ b/src/api/energiatodistus-api.js
@@ -71,9 +71,6 @@ export const energiatodistuksetCount = (fetch, opts) => {
 
   return fetchJson(fetch, url);
 };
-export const energiatodistuksetCountAll = (fetch) =>
-  fetchJson(fetch, energiatodistuksetCountUrl);
-
 
 export const kayttotarkoitusluokat = (fetch, versio) =>
   fetchJson(fetch, `${energiatodistuksetUrl}/kayttotarkoitusluokat/${versio}`);

--- a/src/api/tilastot-api.js
+++ b/src/api/tilastot-api.js
@@ -2,6 +2,7 @@ const baseUrl = '/api/public';
 
 const statisticsUrl = `${baseUrl}/statistics`;
 const kayttotarkoituksetUrl = `${statisticsUrl}/kayttotarkoitukset`
+const energiatodistuksetCountUrl = `${statisticsUrl}/count`;
 
 const fetchJson = (fetch, url) => fetch(url).then(response => response.json());
 
@@ -33,3 +34,6 @@ export const statistics = (fetch, opts) => {
 
   return fetchJson(fetch, url);
 };
+
+export const energiatodistuksetCountAll = (fetch) =>
+  fetchJson(fetch, energiatodistuksetCountUrl);

--- a/src/pages/home.svelte
+++ b/src/pages/home.svelte
@@ -16,8 +16,8 @@
   import Container, { styles as containerStyles } from '@Component/container';
   import Seo from '@Component/seo';
 
-  import * as EtApi from '@/api/energiatodistus-api';
   import * as LaatijaApi from '@/api/laatija-api';
+  import * as TilastotApi from '@/api/tilastot-api';
 
   let etHakuId = '';
   let etHakuKeyword = '';
@@ -27,7 +27,7 @@
 
   let scrollOnAloita = null;
 
-  const etCount = EtApi.energiatodistuksetCountAll(fetch).then(result => {
+  const etCount = TilastotApi.energiatodistuksetCountAll(fetch).then(result => {
     return result.count;
   });
   const laatijatCount = LaatijaApi.laatijatCount(fetch).then(result => {


### PR DESCRIPTION
This gives the full count of valid ET in the database.

Uses the statistics API from [etp-core/#802](https://github.com/solita/etp-core/pull/802)