### PR TITLE
AE-1832 Scroll to top of aineistopalvelu-liittyminen

### DIFF
--- a/src/pages/aineistopalvelu-liittyminen-fi.svelte
+++ b/src/pages/aineistopalvelu-liittyminen-fi.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { onMount } from 'svelte';
   import ButtonLink, {
     styles as buttonLinkStyles
   } from '@Component/buttonlink';
@@ -7,6 +8,11 @@
 
   import SopimusTietopalvelunKaytosta from '@Asset/sopimus-tietopalvelun-kaytosta-luonnos.pdf';
   import TietolupaHakemuslomake from '@Asset/tietolupa-hakemuslomake.pdf';
+
+  let component;
+  onMount(() => {
+    component?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  });
 </script>
 
 <style>
@@ -33,10 +39,13 @@
 </style>
 
 <Container {...containerStyles.beige}>
-  <InfoBlock title={'Energiatodistusrekisterin Aineistopalvelu'}
-    >Energiatodistusrekisterin Aineistopalvelu on tarkoitettu
-    energiatodistustietojen siirtoon rajapinnan kautta rekisteristä
-    Aineistopalvelun käyttäjälle.</InfoBlock>
+  <div bind:this={component}>
+    <InfoBlock title={'Energiatodistusrekisterin Aineistopalvelu'}>
+      Energiatodistusrekisterin Aineistopalvelu on tarkoitettu
+      energiatodistustietojen siirtoon rajapinnan kautta rekisteristä
+      Aineistopalvelun käyttäjälle.
+    </InfoBlock>
+  </div>
 </Container>
 
 <Container {...containerStyles.white}>


### PR DESCRIPTION
The #top anchor works pretty OK if the user is already at the destination page, just somewhere else than the top part. When navigating from elsewhere to the page, though, using the onMount handler works better.