### PR TITLE
Feature/ae 1835

### DIFF
--- a/src/pages/saavutettavuusseloste.svelte
+++ b/src/pages/saavutettavuusseloste.svelte
@@ -8,7 +8,7 @@
   let component;
 
   onMount(() => {
-    component?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    component?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   });
 </script>
 

--- a/src/pages/saavutettavuusseloste.svelte
+++ b/src/pages/saavutettavuusseloste.svelte
@@ -154,7 +154,7 @@
       <ul class="contact-info">
         <li>Saavutettavuuden valvonnan yksikkö</li>
         <li>
-          <Link href="https://www.saavutettavuusvaatimukset.fi/"
+          <Link href="https://www.saavutettavuusvaatimukset.fi/" target="_blank"
             >Saavutettavuusvaatimukset.fi</Link>
         </li>
         <li>saavutettavuus(at)avi.fi vaihde 0295 016 000</li>

--- a/src/pages/saavutettavuusseloste.svelte
+++ b/src/pages/saavutettavuusseloste.svelte
@@ -27,7 +27,7 @@
   }
 
   h3 {
-    @apply underline font-bold;
+    @apply font-bold;
   }
 
   p {


### PR DESCRIPTION
* Remove underlining from saavutettavuusseloste h3 elements
* Scroll to top of saavutettavuusseloste when navigating to the page
* Open link to saavutettavuusvaatimukset.fi in a new window